### PR TITLE
feat: text visibility for dark color gradient fix

### DIFF
--- a/backgroundgen.css
+++ b/backgroundgen.css
@@ -10,6 +10,16 @@ body {
 }
 .container {
   text-align: center;
+  max-width: 450px;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.4);
+  border-radius: 16px;
+  box-shadow: 0 4px 30px rgb(255 255 255 / 10%);
+  padding: 0 25px;
+  backdrop-filter: blur(5px);
+  -webkit-backdrop-filter: blur(5px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
 }
 h1 {
   font-size: 4rem;


### PR DESCRIPTION
added background blur to the container to ensure the container contents are always visible even when the gradient set are dark

## Issue it solved
Fixes #3  

<!-- Brief description of WHAT you’re doing and WHY and add the issue number here (like #123)-->
Texts in the generator container are now visible even with dark color gradients

## Which files you changed?
<!--write to your ans here-->
[backgroundgen.css](https://github.com/Johnnyteck/gradientiser-BgGenerator/blob/jonnie/backgroundgen.css)
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

I added some CSS properties to the container section including a max-width, a background with a low opacity that can be changed to your desired value, a background filter (optimized for other broswers using -WebKit), and also a blur property. So this fixes the issue with dr
-->

## Screenshots 

<!-- optional, remove this section if don't want to include screenshots -->
Extreme case:
|         | before | after |
| ------- | ------ | ----- |
| desktop |   ![Screenshot (155)](https://user-images.githubusercontent.com/73708569/193424016-acfc1281-7835-4d35-89f4-29db7d1de139.png)     |  ![Screenshot (152)](https://user-images.githubusercontent.com/73708569/193423983-3294bb73-a9c7-4a05-afd4-6ff1a17f9399.png)     |
| mobile  |        |       |



